### PR TITLE
Pydantic V2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 1.0.0
 commit = True
 tag = True
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 - Add `setup` feature for modules
 - Add build profiles to control the generation of the bakefile(s)
 - Add duplicate name check to config file validation
-- Upgrade to pydantic 2.x
 - Unit tests
 - Integration (CLI) tests

--- a/docker_printer/__init__.py
+++ b/docker_printer/__init__.py
@@ -1,3 +1,3 @@
 """Composer for dockerfiles"""
 
-__version__ = "0.4.0"
+__version__ = "1.0.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "docker-printer"
 copyright = "2022, David Maxson"
 author = "David Maxson"
-release = "0.4.0"
+release = "1.0.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pyyaml",
     "jinja2",
     "click",
-    "pydantic==1.*",
+    "pydantic==2.*",
     "typer",
     "rich"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
 click
-pydantic==1.*
+pydantic==2.*
 typer
 rich


### PR DESCRIPTION
This will prevent Pydantic V1 users from using docker-printer. Maybe shift to suggesting that people use `pipx` to run docker-printer instead?